### PR TITLE
Switching ChainlinkOracleAddress to a command line param rather than being pulled from the Chainlink process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Market Sync
+
 Synchronise job specifications from any given Chainlink node to the [LinkPool Market](https://market.link):
 
 - Detects if there's job specifications on the provided Chainlink node that don't exist on the market.
@@ -12,13 +13,14 @@ Synchronise job specifications from any given Chainlink node to the [LinkPool Ma
 Download the latest version from [releases](https://github.com/linkpoolio/market-sync/releases).
 
 Alternatively, you can use the Docker container:
+
 ```
 docker pull linkpool/market-sync
 ```
 
 ## Usage
 
-Market sync is a simple CLI tool that requires you to provide your Chainlink node login credentials, and LinkPool Market 
+Market sync is a simple CLI tool that requires you to provide your Chainlink node login credentials, and LinkPool Market
 API keys.
 
 ### Preconditions
@@ -34,6 +36,7 @@ market-sync \
     -e admin@node.local \
     -p twochains \
     -u http://localhost:6688 \
+    -o 0xa00000000000000000000000000000000000000f \
     -a 31896afb-fa1c-4b30-b9a7-d7b5284cfab7 \
     -s RnscNLRnfWVRBuuRipWDRnscNLRnfWVRBuuRipWDRnscNLRnfWVRBuuRipWD
 ```
@@ -44,6 +47,7 @@ market-sync \
 CHAINLINK_EMAIL=admin@node.local; \
 CHAINLINK_PASSWORD=twochains; \
 CHAINLINK_URL=http://localhost:6688; \
+CHAINLINK_ORACLE_ADDRESS=0xa00000000000000000000000000000000000000f; \
 MARKET_ACCESS_KEY=31896afb-fa1c-4b30-b9a7-d7b5284cfab7; \
 MARKET_SECRET_KEY=RnscNLRnfWVRBuuRipWDRnscNLRnfWVRBuuRipWDRnscNLRnfWVRBuuRipWD; \
 market-sync

--- a/application.go
+++ b/application.go
@@ -22,13 +22,14 @@ type Application struct {
 }
 
 type Config struct {
-	UI                *input.UI
-	ChainlinkEmail    string
-	ChainlinkPassword string
-	ChainlinkURL      string
+	UI                      *input.UI
+	ChainlinkEmail          string
+	ChainlinkPassword       string
+	ChainlinkURL            string
+	ChainlinkOracleAddress	common.Address
 
-	MarketAccessKey string
-	MarketSecretKey string
+	MarketAccessKey         string
+	MarketSecretKey         string
 }
 
 func NewApplication(config *Config) (*Application, error) {
@@ -56,14 +57,13 @@ func NewApplication(config *Config) (*Application, error) {
 func (a *Application) MarketNode() (*client.MarketNode, error) {
 	yellow := color.New(color.FgYellow).SprintFunc()
 
-	oracleNilError := errors.New("Chainlink oracle address is nil, please ensure `ORACLE_CONTRACT_ADDRESS` is set in configuration")
+	oracleNilError := errors.New("Chainlink oracle address is nil, please ensure chainlink-oracle-address is being passed in as a flag.")
 	cfg, err := a.chainlink.Config()
 	if err != nil {
 		return nil, err
-	} else if cfg.Data.Attributes.OracleContractAddress == nil {
-		return nil, oracleNilError
 	}
-	oracle := cfg.Data.Attributes.OracleContractAddress
+
+	oracle := a.config.ChainlinkOracleAddress
 	chainId := cfg.Data.Attributes.ETHChainID
 
 	fmt.Printf("%s %s\n", yellow("Oracle Address:"), oracle.String())
@@ -71,7 +71,7 @@ func (a *Application) MarketNode() (*client.MarketNode, error) {
 		return nil, oracleNilError
 	}
 
-	node, err := a.market.NodeByOracleAddress(oracle, chainId)
+	node, err := a.market.NodeByOracleAddress(&oracle, chainId)
 	if err != nil {
 		return nil, errors.New("Chainlink node not found on the Market, create it before running this tool")
 	}

--- a/client/models.go
+++ b/client/models.go
@@ -91,7 +91,6 @@ type ChainlinkJobSpecCreated struct {
 type ChainlinkConfig struct {
 	Data struct {
 		Attributes struct {
-			OracleContractAddress *common.Address `json:"oracleContractAddress"`
 			ETHChainID            int             `json:"ethChainId"`
 		} `json:"attributes"`
 	} `json:"data"`

--- a/main.go
+++ b/main.go
@@ -7,16 +7,18 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/tcnksm/go-input"
+	"github.com/ethereum/go-ethereum/common"
 	"os"
 	"strings"
 )
 
 const (
-	ChainlinkEmailFlag    = "chainlink-email"
-	ChainlinkPasswordFlag = "chainlink-password"
-	ChainlinkURLFlag      = "chainlink-url"
-	MarketAccessKeyFlag   = "market-access-key"
-	marketSecretKeyFlag   = "market-secret-key"
+	ChainlinkEmailFlag         = "chainlink-email"
+	ChainlinkPasswordFlag      = "chainlink-password"
+	ChainlinkURLFlag           = "chainlink-url"
+	ChainlinkOracleAddressFlag = "chainlink-oracle-address"
+	MarketAccessKeyFlag        = "market-access-key"
+	marketSecretKeyFlag        = "market-secret-key"
 )
 
 func generateCmd() *cobra.Command {
@@ -33,12 +35,14 @@ All flags can be set as environment variables, eg: NODE_URL, NODE_PASSWORD`,
 	newcmd.Flags().StringP(ChainlinkEmailFlag, "e", "", "chainlink node email")
 	newcmd.Flags().StringP(ChainlinkPasswordFlag, "p", "", "chainlink node password")
 	newcmd.Flags().StringP(ChainlinkURLFlag, "u", "", "chainlink node url")
+	newcmd.Flags().StringP(ChainlinkOracleAddressFlag, "o", "", "chainlink oracle address")
 	newcmd.Flags().StringP(MarketAccessKeyFlag, "a", "", "market access key")
 	newcmd.Flags().StringP(marketSecretKeyFlag, "s", "", "market secret key")
 
 	_ = newcmd.MarkFlagRequired(ChainlinkEmailFlag)
 	_ = newcmd.MarkFlagRequired(ChainlinkPasswordFlag)
 	_ = newcmd.MarkFlagRequired(ChainlinkURLFlag)
+	_ = newcmd.MarkFlagRequired(ChainlinkOracleAddressFlag)
 	_ = newcmd.MarkFlagRequired(MarketAccessKeyFlag)
 	_ = newcmd.MarkFlagRequired(marketSecretKeyFlag)
 	presetRequiredFlags(newcmd)
@@ -58,12 +62,13 @@ func run(_ *cobra.Command, _ []string) {
 	yellow := color.New(color.FgYellow).SprintFunc()
 	color.Blue("Starting the Market Sync CLI")
 	a, err := NewApplication(&Config{
-		UI:                input.DefaultUI(),
-		ChainlinkEmail:    viper.GetString(ChainlinkEmailFlag),
-		ChainlinkPassword: viper.GetString(ChainlinkPasswordFlag),
-		ChainlinkURL:      viper.GetString(ChainlinkURLFlag),
-		MarketAccessKey:   viper.GetString(MarketAccessKeyFlag),
-		MarketSecretKey:   viper.GetString(marketSecretKeyFlag),
+		UI:                     input.DefaultUI(),
+		ChainlinkEmail:         viper.GetString(ChainlinkEmailFlag),
+		ChainlinkPassword:      viper.GetString(ChainlinkPasswordFlag),
+		ChainlinkURL:           viper.GetString(ChainlinkURLFlag),
+		ChainlinkOracleAddress: parseOracleAddress(viper.GetString(ChainlinkOracleAddressFlag)),
+		MarketAccessKey:        viper.GetString(MarketAccessKeyFlag),
+		MarketSecretKey:        viper.GetString(marketSecretKeyFlag),
 	})
 	if err != nil {
 		exit(err)
@@ -82,6 +87,10 @@ func run(_ *cobra.Command, _ []string) {
 
 	color.Blue("Market Sync Complete")
 	exit(nil)
+}
+
+func parseOracleAddress(address string) common.Address {
+	return common.HexToAddress(address)
 }
 
 func main() {


### PR DESCRIPTION
In versions 0.9.x of Chainlink, it looks like they removed the `ORACLE_CONTRACT_ADDRESS` config option: https://github.com/smartcontractkit/chainlink/blob/master/docs/CHANGELOG.md#0817---2020-09-28

This patch allows you to pass your Oracle Contract Address in as a command line param (the `-o` option). It parses the address with `common.HexToAddress` and passes the reference through as normal.

Thoughts on this PR to support 0.9.x versions of the Chainlink client?