### PR TITLE
Added support for TLS certificate and authentication to the market.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 /Godeps/
 
 # End of https://www.gitignore.io/api/go
+
+### Goland
+.idea/

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ market-sync \
 ```
 CHAINLINK_EMAIL=admin@node.local; \
 CHAINLINK_PASSWORD=twochains; \
-CHAINLINK_URL=http://localhost:6688; \
+CHAINLINK_URL=https://localhost:6689; \
 CHAINLINK_ORACLE_ADDRESS=0xa00000000000000000000000000000000000000f; \
 CHAINLINK_CERTIFICATE_FILE=/path/to/certificate_file.crt
 MARKET_ACCESS_KEY=31896afb-fa1c-4b30-b9a7-d7b5284cfab7; \

--- a/README.md
+++ b/README.md
@@ -46,8 +46,36 @@ market-sync \
 ```
 CHAINLINK_EMAIL=admin@node.local; \
 CHAINLINK_PASSWORD=twochains; \
+CHAINLINK_URL=https://localhost:6689; \
+CHAINLINK_ORACLE_ADDRESS=0xa00000000000000000000000000000000000000f; \
+MARKET_ACCESS_KEY=31896afb-fa1c-4b30-b9a7-d7b5284cfab7; \
+MARKET_SECRET_KEY=RnscNLRnfWVRBuuRipWDRnscNLRnfWVRBuuRipWDRnscNLRnfWVRBuuRipWD; \
+market-sync
+```
+
+## HTTPS Connections to Your Chainlink Node
+If you have enabled HTTPS connections to your Chainlink node you will need to pass in the certificate using the -c option.
+
+### Using Flags
+
+```
+market-sync \
+    -e admin@node.local \
+    -p twochains \
+    -u http://localhost:6688 \
+    -o 0xa00000000000000000000000000000000000000f \
+    -a 31896afb-fa1c-4b30-b9a7-d7b5284cfab7 \
+    -s RnscNLRnfWVRBuuRipWDRnscNLRnfWVRBuuRipWDRnscNLRnfWVRBuuRipWD \
+    -c /path/to/certificate_file.crt
+```
+### Using Environment Variables
+
+```
+CHAINLINK_EMAIL=admin@node.local; \
+CHAINLINK_PASSWORD=twochains; \
 CHAINLINK_URL=http://localhost:6688; \
 CHAINLINK_ORACLE_ADDRESS=0xa00000000000000000000000000000000000000f; \
+CHAINLINK_CERTIFICATE_FILE=/path/to/certificate_file.crt
 MARKET_ACCESS_KEY=31896afb-fa1c-4b30-b9a7-d7b5284cfab7; \
 MARKET_SECRET_KEY=RnscNLRnfWVRBuuRipWDRnscNLRnfWVRBuuRipWDRnscNLRnfWVRBuuRipWD; \
 market-sync

--- a/application.go
+++ b/application.go
@@ -22,21 +22,23 @@ type Application struct {
 }
 
 type Config struct {
-	UI                      *input.UI
-	ChainlinkEmail          string
-	ChainlinkPassword       string
-	ChainlinkURL            string
-	ChainlinkOracleAddress	common.Address
+	UI                       *input.UI
+	ChainlinkEmail           string
+	ChainlinkPassword        string
+	ChainlinkURL             string
+	ChainlinkCertificateFile string
+	ChainlinkOracleAddress   common.Address
 
-	MarketAccessKey         string
-	MarketSecretKey         string
+	MarketAccessKey string
+	MarketSecretKey string
 }
 
 func NewApplication(config *Config) (*Application, error) {
 	c, err := client.NewChainlink(&client.ChainlinkClientConfig{
-		Email:    config.ChainlinkEmail,
-		Password: config.ChainlinkPassword,
-		URL:      config.ChainlinkURL,
+		Email:           config.ChainlinkEmail,
+		Password:        config.ChainlinkPassword,
+		URL:             config.ChainlinkURL,
+		CertificateFile: config.ChainlinkCertificateFile,
 	})
 	if err != nil {
 		return nil, err

--- a/client/market.go
+++ b/client/market.go
@@ -31,7 +31,8 @@ func NewMarket(accessKey, secretKey string) (*Market, error) {
 		secretKey:  secretKey,
 		activeUser: &MarketUser{},
 	}
-	err := m.SetActiveUser()
+	err := m.AuthenticateUser()
+	err = m.SetActiveUser()
 	return m, err
 }
 
@@ -43,6 +44,17 @@ func (m *Market) SetActiveUser() error {
 	_, err := m.do(
 		http.MethodGet,
 		"/user",
+		nil,
+		http.StatusOK,
+		m.activeUser,
+	)
+	return err
+}
+
+func (m *Market) AuthenticateUser() error {
+	_, err := m.do(
+		http.MethodGet,
+		"/keys",
 		nil,
 		http.StatusOK,
 		m.activeUser,

--- a/client/models.go
+++ b/client/models.go
@@ -6,9 +6,10 @@ import (
 )
 
 type ChainlinkClientConfig struct {
-	Email    string
-	Password string
-	URL      string
+	Email           string
+	Password        string
+	URL             string
+	CertificateFile string
 }
 
 type ChainlinkErrors struct {
@@ -33,8 +34,9 @@ type ChainlinkBridgeTypeAttributes struct {
 }
 
 type ChainlinkSession struct {
-	Email    string `json:"email"`
-	Password string `json:"password"`
+	Email           string `json:"email"`
+	Password        string `json:"password"`
+	CertificateFile string `json:"certificate"`
 }
 
 type ChainlinkMeta struct {
@@ -91,7 +93,7 @@ type ChainlinkJobSpecCreated struct {
 type ChainlinkConfig struct {
 	Data struct {
 		Attributes struct {
-			ETHChainID            int             `json:"ethChainId"`
+			ETHChainID int `json:"ethChainId"`
 		} `json:"attributes"`
 	} `json:"data"`
 }

--- a/main.go
+++ b/main.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"fmt"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/tcnksm/go-input"
-	"github.com/ethereum/go-ethereum/common"
 	"os"
 	"strings"
 )
@@ -17,6 +17,7 @@ const (
 	ChainlinkPasswordFlag      = "chainlink-password"
 	ChainlinkURLFlag           = "chainlink-url"
 	ChainlinkOracleAddressFlag = "chainlink-oracle-address"
+	ChainlinkCertificateFile   = "chainlink-certificate-file"
 	MarketAccessKeyFlag        = "market-access-key"
 	marketSecretKeyFlag        = "market-secret-key"
 )
@@ -36,6 +37,8 @@ All flags can be set as environment variables, eg: NODE_URL, NODE_PASSWORD`,
 	newcmd.Flags().StringP(ChainlinkPasswordFlag, "p", "", "chainlink node password")
 	newcmd.Flags().StringP(ChainlinkURLFlag, "u", "", "chainlink node url")
 	newcmd.Flags().StringP(ChainlinkOracleAddressFlag, "o", "", "chainlink oracle address")
+	newcmd.Flags().StringP(ChainlinkCertificateFile, "c", "", "chainlink node certificate file path")
+
 	newcmd.Flags().StringP(MarketAccessKeyFlag, "a", "", "market access key")
 	newcmd.Flags().StringP(marketSecretKeyFlag, "s", "", "market secret key")
 
@@ -62,13 +65,14 @@ func run(_ *cobra.Command, _ []string) {
 	yellow := color.New(color.FgYellow).SprintFunc()
 	color.Blue("Starting the Market Sync CLI")
 	a, err := NewApplication(&Config{
-		UI:                     input.DefaultUI(),
-		ChainlinkEmail:         viper.GetString(ChainlinkEmailFlag),
-		ChainlinkPassword:      viper.GetString(ChainlinkPasswordFlag),
-		ChainlinkURL:           viper.GetString(ChainlinkURLFlag),
-		ChainlinkOracleAddress: parseOracleAddress(viper.GetString(ChainlinkOracleAddressFlag)),
-		MarketAccessKey:        viper.GetString(MarketAccessKeyFlag),
-		MarketSecretKey:        viper.GetString(marketSecretKeyFlag),
+		UI:                       input.DefaultUI(),
+		ChainlinkEmail:           viper.GetString(ChainlinkEmailFlag),
+		ChainlinkPassword:        viper.GetString(ChainlinkPasswordFlag),
+		ChainlinkURL:             viper.GetString(ChainlinkURLFlag),
+		ChainlinkCertificateFile: viper.GetString(ChainlinkCertificateFile),
+		ChainlinkOracleAddress:   parseOracleAddress(viper.GetString(ChainlinkOracleAddressFlag)),
+		MarketAccessKey:          viper.GetString(MarketAccessKeyFlag),
+		MarketSecretKey:          viper.GetString(marketSecretKeyFlag),
 	})
 	if err != nil {
 		exit(err)


### PR DESCRIPTION
Enabling HTTPS connections on your node is an option described in the chainlink documentation in the [Node Operators](https://docs.chain.link/docs/enabling-https-connections) section.  When enabled the market-sync no longer works.  You get, "x509: certificate signed by unknown authority".  

Added a new option, "-c",  to point to the certificate file on the filesystem.  

Also noticed that the connection to market was failing in the initial sessions call.  Added the authentication call, /keys, before the /sessions call to fix it. 